### PR TITLE
修复使用其他字体时，高度不正确

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 需要 PIL 库 `pip install Pillow`
 
 ```
-usage: marker.py [-h] [-f FILE] [-m MARK] [-o OUT] [-c COLOR] [-s SPACE]
-                 [-a ANGEL] [--size SIZE] [--opacity OPACITY]
+usage: marker.py [-h] [-f FILE] [-m MARK] [-o OUT] [-c COLOR] [-s SPACE] [-a ANGLE] [--font-family FONT_FAMILY] [--font-height-crop FONT_HEIGHT_CROP] [--size SIZE]
+                 [--opacity OPACITY] [--quality QUALITY]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -20,8 +20,17 @@ optional arguments:
                         text color like '#000000', default is #8B8B1B
   -s SPACE, --space SPACE
                         space between watermarks, default is 75
-  -a ANGEL, --angel ANGEL
-                        rotate angel of watermarks, default is 30
+  -a ANGLE, --angle ANGLE
+                        rotate angle of watermarks, default is 30
+  --font-family FONT_FAMILY
+                        font family of text, default is './font/青鸟华光简琥珀.ttf'
+                        using font in system just by font file name
+                        for example 'PingFang.ttc', which is default installed on macOS
+  --font-height-crop FONT_HEIGHT_CROP
+                        change watermark font height crop
+                        float will be parsed to factor; int will be parsed to value
+                        default is '1.2', meaning 1.2 times font size
+                        this useful with CJK font, because line height may be higher than size
   --size SIZE           font size of text, default is 50
   --opacity OPACITY     opacity of watermarks, default is 0.15
   --quality QUALITY     quality of output images, default is 90

--- a/marker.py
+++ b/marker.py
@@ -5,6 +5,7 @@ import argparse
 import os
 import sys
 import math
+import textwrap
 
 from PIL import Image, ImageFont, ImageDraw, ImageEnhance, ImageChops
 
@@ -88,7 +89,7 @@ def gen_mark(args):
         ''' 在im图片上添加水印 im为打开的原图'''
 
         # 计算斜边长度
-        c = int(math.sqrt(im.size[0]*im.size[0] + im.size[1]*im.size[1]))
+        c = int(math.sqrt(im.size[0] * im.size[0] + im.size[1] * im.size[1]))
 
         # 以斜边长度为宽高创建大图（旋转后大图才足以覆盖原图）
         mark2 = Image.new(mode='RGBA', size=(c, c))
@@ -97,7 +98,7 @@ def gen_mark(args):
         y, idx = 0, 0
         while y < c:
             # 制造x坐标错位
-            x = -int((mark.size[0] + args.space)*0.5*idx)
+            x = -int((mark.size[0] + args.space) * 0.5 * idx)
             idx = (idx + 1) % 2
 
             while x < c:
@@ -113,7 +114,7 @@ def gen_mark(args):
         if im.mode != 'RGBA':
             im = im.convert('RGBA')
         im.paste(mark2,  # 大图
-                 (int((im.size[0]-c)/2), int((im.size[1]-c)/2)),  # 坐标
+                 (int((im.size[0] - c) / 2), int((im.size[1] - c) / 2)),  # 坐标
                  mask=mark2.split()[3])
         del mark2
         return im
@@ -122,7 +123,7 @@ def gen_mark(args):
 
 
 def main():
-    parse = argparse.ArgumentParser()
+    parse = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parse.add_argument("-f", "--file", type=str,
                        help="image file path or directory")
     parse.add_argument("-m", "--mark", type=str, help="watermark content")
@@ -135,14 +136,18 @@ def main():
     parse.add_argument("-a", "--angle", default=30, type=int,
                        help="rotate angle of watermarks, default is 30")
     parse.add_argument("--font-family", default="./font/青鸟华光简琥珀.ttf", type=str,
-                       help="font family of text, default is './font/青鸟华光简琥珀.ttf'.\n"
-                            "using font in system just by font file name.\n"
-                            "for example 'PingFang.ttc', which is default installed on macOS.")
+                       help=textwrap.dedent('''\
+                       font family of text, default is './font/青鸟华光简琥珀.ttf'
+                       using font in system just by font file name
+                       for example 'PingFang.ttc', which is default installed on macOS
+                       '''))
     parse.add_argument("--font-height-crop", default="1.2", type=str,
-                       help="change watermark font height crop.\n"
-                            "float will be parsed to factor; int will be parsed to value.\n"
-                            "default is '1.2', meaning 1.2 times font size\n"
-                            "This useful with CJK font, because line height may be higher than size.")
+                       help=textwrap.dedent('''\
+                       change watermark font height crop
+                       float will be parsed to factor; int will be parsed to value
+                       default is '1.2', meaning 1.2 times font size
+                       this useful with CJK font, because line height may be higher than size
+                       '''))
     parse.add_argument("--size", default=50, type=int,
                        help="font size of text, default is 50")
     parse.add_argument("--opacity", default=0.15, type=float,

--- a/marker.py
+++ b/marker.py
@@ -8,10 +8,6 @@ import math
 
 from PIL import Image, ImageFont, ImageDraw, ImageEnhance, ImageChops
 
-# TTF_FONT = u'./font/青鸟华光简琥珀.ttf'
-TTF_FONT = os.path.join("font", "青鸟华光简琥珀.ttf")
-TTF_FONT = os.path.join(os.path.dirname(os.path.abspath(__file__)), TTF_FONT)
-
 
 def add_mark(imagePath, mark, args):
     '''
@@ -20,8 +16,8 @@ def add_mark(imagePath, mark, args):
     im = Image.open(imagePath)
 
     image = mark(im)
+    name = os.path.basename(imagePath)
     if image:
-        name = os.path.basename(imagePath)
         if not os.path.exists(args.out):
             os.mkdir(args.out)
 
@@ -62,18 +58,23 @@ def gen_mark(args):
     '''
     生成mark图片，返回添加水印的函数
     '''
-    # 字体宽度
+    # 字体宽度、高度
+    is_height_crop_float = '.' in args.font_height_crop  # not good but work
     width = len(args.mark) * args.size
+    if is_height_crop_float:
+        height = round(args.size * float(args.font_height_crop))
+    else:
+        height = int(args.font_height_crop)
 
     # 创建水印图片(宽度、高度)
-    mark = Image.new(mode='RGBA', size=(width, args.size))
+    mark = Image.new(mode='RGBA', size=(width, height))
 
     # 生成文字
     draw_table = ImageDraw.Draw(im=mark)
     draw_table.text(xy=(0, 0),
                     text=args.mark,
                     fill=args.color,
-                    font=ImageFont.truetype(TTF_FONT,
+                    font=ImageFont.truetype(args.font_family,
                                             size=args.size))
     del draw_table
 
@@ -133,6 +134,15 @@ def main():
                        help="space between watermarks, default is 75")
     parse.add_argument("-a", "--angle", default=30, type=int,
                        help="rotate angle of watermarks, default is 30")
+    parse.add_argument("--font-family", default="./font/青鸟华光简琥珀.ttf", type=str,
+                       help="font family of text, default is './font/青鸟华光简琥珀.ttf'.\n"
+                            "using font in system just by font file name.\n"
+                            "for example 'PingFang.ttc', which is default installed on macOS.")
+    parse.add_argument("--font-height-crop", default="1.2", type=str,
+                       help="change watermark font height crop.\n"
+                            "float will be parsed to factor; int will be parsed to value.\n"
+                            "default is '1.2', meaning 1.2 times font size\n"
+                            "This useful with CJK font, because line height may be higher than size.")
     parse.add_argument("--size", default=50, type=int,
                        help="font size of text, default is 50")
     parse.add_argument("--opacity", default=0.15, type=float,


### PR DESCRIPTION
例如使用 'PingFang.ttc' 字体下 1/4 部分左右会没有

增加了两个选项可控制字体与字体高度截断